### PR TITLE
Minor improvements to docker

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
         "start": "next start",
         "docker:build": "docker build -t frontend .",
         "docker:clean": "docker rm -f frontend || true",
-        "docker:run": "docker run -p 3000:3000 -d --name frontend frontend && npm run docker:logs",
+        "docker:run": "docker run -p 3000:3000 --name frontend frontend",
         "docker:stop": "docker stop frontend",
         "docker:start": "docker start frontend && npm run docker:logs",
         "docker:logs": "docker logs -f frontend",


### PR DESCRIPTION
Using the tag `-d` you suppress the logs, if you remove this you do not need to launch the `docker logs` command