### PR TITLE
Fixed socket error on MacOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "scripts": {
     "preinstall": "chmod +x install.sh && ./install.sh",
     "postinstall": "robo wordpress:setup",
-    "start": "wp server"
+    "start": "wp server --host=0.0.0.0"
   }
 }


### PR DESCRIPTION
According to issue https://github.com/postlight/headless-wp-starter/issues/33 this change should fix ECONNREFUSED on Mac.

Enjoy! 😄 