### PR TITLE
Remove --yes param from 'db create'

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -36,7 +36,7 @@ class RoboFile extends \Robo\Tasks {
 		$this->wp( 'core download --version=4.9.2 --locale=en_US --force' );
 		$this->wp( 'core config --dbname=' . $opts['wp-db-name'] . ' --dbuser=' . $opts['wp-db-name'] . ' --dbpass=' . $opts['wp-db-name'] . ' --dbhost=0.0.0.0' );
 		$this->wp( 'db drop --yes' );
-		$this->wp( 'db create --yes' );
+		$this->wp( 'db create' );
 
 		$install_command = implode( ' ', array(
 			'core install',


### PR DESCRIPTION
Trying setting up the project in Mac OS in High Sierra 10.13.3 when it runs `robo wordpress:setup` you are getting an error saying that is not possible to recognize the `--yes` parameter, so the rest of robo wordpress scripts were not running. 

Looks the parameter `--yes` is invalid for the command `db create`, after removed it I was able to run `robo wordpress:setup` without problems and have the wordpress installation configured correctly.