### PR TITLE
Adjustments for MySQL 8

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -79,7 +79,7 @@ class RoboFile extends \Robo\Tasks {
 
         $this->_exec(
             'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip . " -e 'create user if not exists "
-            . $opts['wp-db-name'] . "@localhost identified by \"" . $opts['wp-db-name'] . "\"'"
+            . $opts['wp-db-name'] . "@localhost identified with mysql_native_password by \"" . $opts['wp-db-name'] . "\"'"
         );
         $this->_exec(
             'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -79,7 +79,7 @@ class RoboFile extends \Robo\Tasks {
 
         $this->_exec(
             'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip . " -e 'create user if not exists "
-            . $opts['wp-db-name'] . "'"
+            . $opts['wp-db-name'] . "@localhost identified by \"" . $opts['wp-db-name'] . "\"'"
         );
         $this->_exec(
             'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip
@@ -87,7 +87,7 @@ class RoboFile extends \Robo\Tasks {
         );
         $this->_exec(
             'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip . ' -e "grant all privileges on ' . $opts['wp-db-name']
-            . '.* to ' . $opts['wp-db-name'] . "@localhost identified by '" . $opts['wp-db-name'] . "'\""
+            . '.* to ' . $opts['wp-db-name'] . "@localhost\""
         );
 
         $this->_exec( 'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip . " -e 'flush privileges'" );

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -93,6 +93,7 @@ class RoboFile extends \Robo\Tasks {
         $this->_exec( 'mysql -uroot -p' . $db_pass . ' -h ' . $db_ip . " -e 'flush privileges'" );
 
         $this->wp( 'core download --version=4.9.6 --locale=en_US --force' );
+        $this->_exec( 'rm wordpress/wp-config.php > /dev/null 2>&1 || true' );
         $this->wp(
             'core config --dbname=' . $opts['wp-db-name'] . ' --dbuser=' . $opts['wp-db-name'] . ' --dbpass='
             . $opts['wp-db-name'] . ' --dbhost=' . $db_ip

--- a/mysql_config.sh
+++ b/mysql_config.sh
@@ -2,7 +2,7 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # If there's no password set for MySQL (first-time install), add one and cleanup
-    if mysql -uroot -e ""; then
+    if mysql -uroot -e "" > /dev/null 2>&1; then
         mysql -uroot <<_EOF_
           ALTER USER 'root'@'localhost' IDENTIFIED BY 'root';
           DELETE FROM mysql.user WHERE User='';

--- a/mysql_config.sh
+++ b/mysql_config.sh
@@ -4,7 +4,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     # If there's no password set for MySQL (first-time install), add one and cleanup
     if mysql -uroot -e ""; then
         mysql -uroot <<_EOF_
-          UPDATE mysql.user SET authentication_string=PASSWORD('root') WHERE User='root';
+          ALTER USER 'root'@'localhost' IDENTIFIED BY 'root';
           DELETE FROM mysql.user WHERE User='';
           DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
           DROP DATABASE IF EXISTS test;

--- a/mysql_config.sh
+++ b/mysql_config.sh
@@ -2,7 +2,7 @@
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # If there's no password set for MySQL (first-time install), add one and cleanup
-    if mysql -uroot; then
+    if mysql -uroot -e ""; then
         mysql -uroot <<_EOF_
           UPDATE mysql.user SET authentication_string=PASSWORD('root') WHERE User='root';
           DELETE FROM mysql.user WHERE User='';


### PR DESCRIPTION
`brew install mysql` now installs MySQL 8 by default. The current install script has a couple of issues with MySQL 8. Each commit should clearly document (more or less) the reason behind the fix but with these changes in place I was able to run `yarn install` successfully.

This will likely solve a couple of GitHub issues like #104, #94 and #88 (maybe more) but there may be some more follow up (need to read through all of the issues a little more).