### PR TITLE
fix: Both production and development should use server.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The primary theme code is located in `wordpress/wp-content/themes/postlight-head
 To spin up the frontend client app, run the following commands:
 
 ```zsh
-> cd frontend && yarn install && yarn run dev
+> cd frontend && yarn install && yarn start
 ```
 
 The Next.js app will be running on [http://localhost:3000](http://localhost:3000).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "dev": "node server.js",
         "build": "next build",
-        "start": "next start",
+        "start": "node server.js",
         "docker:build": "docker build -t frontend .",
         "docker:clean": "docker rm -f frontend || true",
         "docker:run": "docker run -p 3000:3000 --name frontend frontend",


### PR DESCRIPTION
This should resolve the issues described in #80. See the commit message for details.