### PR TITLE
Using PureComponent and Promise.all to improve performance

### DIFF
--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -1,15 +1,8 @@
-import React, { Component } from "react";
-import Link from "next/link";
+import React, { PureComponent } from "react";
 import Head from "next/head";
-import Menu from "./Menu.js";
-import { Config } from "../config.js";
 import stylesheet from '../src/styles/style.scss'
 
-class Header extends Component {
-    constructor() {
-        super();
-    }
-
+class Header extends PureComponent {
     render() {
 
         return (

--- a/frontend/components/Menu.js
+++ b/frontend/components/Menu.js
@@ -1,16 +1,11 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import Link from "next/link";
-import { Config } from "../config.js";
 
 const linkStyle = {
     marginRight: 15
 };
 
-class Menu extends Component {
-  constructor() {
-      super();
-  }
-
+class Menu extends PureComponent {
   getSlug(url) {
       const parts = url.split("/");
       return parts.length > 2 ? parts[parts.length - 2] : "";

--- a/frontend/components/PageWrapper.js
+++ b/frontend/components/PageWrapper.js
@@ -1,16 +1,20 @@
-import React from "react";
+import React, { PureComponent } from "react";
 import { Config } from "../config.js";
 
 const PageWrapper = Comp => (
-  class extends React.Component {
+  class extends PureComponent {
     static async getInitialProps(args) {
-      const headerMenuRes = await fetch(
+      const [wrappedInitialProps, headerMenuRes] = await Promise.all([
+        Comp.getInitialProps ? Comp.getInitialProps(args) : null,
+        fetch(
         `${Config.apiUrl}/wp-json/menus/v1/menus/header-menu`
-      );
+        ),
+      ]);
+
       const headerMenu = await headerMenuRes.json();
       return {
         headerMenu,
-        ...(Comp.getInitialProps ? await Comp.getInitialProps(args) : null),
+        ...wrappedInitialProps,
       };
     }
 

--- a/frontend/pages/category.js
+++ b/frontend/pages/category.js
@@ -29,9 +29,9 @@ class Category extends Component {
         if (this.props.categories.length == 0)
             return <Error statusCode={404} />;
 
-        const posts = this.props.posts.map((post, index) => {
+        const posts = this.props.posts.map((post) => {
             return (
-                <ul key={index}>
+                <ul key={index.id}>
                     <li>
                         <Link
                             as={`/post/${post.slug}`}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -29,9 +29,9 @@ class Index extends Component {
     }
 
     render() {
-        const posts = this.props.posts.map((post, index) => {
+        const posts = this.props.posts.map((post) => {
             return (
-                <ul key={index}>
+                <ul key={post.id}>
                     <li>
                         <Link
                             as={`/post/${post.slug}`}
@@ -43,9 +43,9 @@ class Index extends Component {
                 </ul>
             );
         });
-        const pages = this.props.pages.map((page, index) => {
+        const pages = this.props.pages.map((page) => {
             return (
-                <ul key={index}>
+                <ul key={page.id}>
                     <li>
                         <Link
                             as={`/page/${page.slug}`}

--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -1,57 +1,54 @@
 import Layout from "../components/Layout.js";
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import fetch from "isomorphic-unfetch";
 import Error from "next/error";
 import PageWrapper from "../components/PageWrapper.js";
 import Menu from "../components/Menu.js";
 import { Config } from "../config.js";
 
-class Preview extends Component {
-    constructor() {
-        super();
-        this.state = {
-            post: null
-        };
-    }
+class Preview extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      post: null
+    };
+  }
 
-    componentDidMount() {
-        const { id, wpnonce } = this.props.url.query;
-        fetch(
-            `${
-                Config.apiUrl
-            }/wp-json/postlight/v1/post/preview?id=${id}&_wpnonce=${wpnonce}`,
-            { credentials: "include" } // required for cookie nonce auth
-        )
-            .then(res => res.json())
-            .then(res => {
-                this.setState({
-                    post: res
-                });
-            });
-    }
+  async componentDidMount() {
+    const { id, wpnonce } = this.props.url.query;
+    const previewRes = await fetch(
+      `${
+      Config.apiUrl
+      }/wp-json/postlight/v1/post/preview?id=${id}&_wpnonce=${wpnonce}`,
+      { credentials: "include" } // required for cookie nonce auth
+    );
 
-    render() {
-        if (
-            this.state.post &&
-            this.state.post.code &&
-            this.state.post.code === "rest_cookie_invalid_nonce"
-        )
-            return <Error statusCode={404} />;
+    const post = await previewRes.json();
+    this.setState({ post });
+  }
 
-        return (
-            <Layout>
-                <Menu menu={this.props.headerMenu} />
-                <h1>{this.state.post ? this.state.post.title.rendered : ""}</h1>
-                <div
-                    dangerouslySetInnerHTML={{
-                        __html: this.state.post
-                            ? this.state.post.content.rendered
-                            : ""
-                    }}
-                />
-            </Layout>
-        );
-    }
+  render() {
+    if (
+      this.state.post &&
+      this.state.post.code &&
+      this.state.post.code === "rest_cookie_invalid_nonce"
+    )
+      return <Error statusCode={404} />;
+
+    return (
+      <Layout>
+        <Menu menu={this.props.headerMenu} />
+        <h1>{this.state.post ? this.state.post.title.rendered : ""}</h1>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: this.state.post
+              ? this.state.post.content.rendered
+              : ""
+          }}
+        />
+      </Layout>
+    );
+  }
 }
 
 export default PageWrapper(Preview);


### PR DESCRIPTION
Hi, thank you for putting this library together. I've been enjoying using it and would like to send some of the changes I have made locally back upstream so that others may benefit from them.

Here is what this pull request contains:
- Rather than waiting twice in PageWrapper, used Promise.all in `getInitialProps()`. This should grant a small performance improvement.
- Used IDs for keys instead of index (https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318)
- Removed useless constructors
- Switched in PureComponent instead of Component (granted, this probably isn't a big deal here, because most of these components should only be rendering once-- I prefer to start with PureComponents and work away from them if necessary https://medium.com/airbnb-engineering/recent-web-performance-fixes-on-airbnb-listing-pages-6cd8d93df6f4)

Please let me know if you would like to see any additional changes.

CC: @ftrain @ginatrapani @adampash @johnholdun @droob

Thanks again,

Josh