### PR TITLE
feat: expose docker mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
 RUN dpkg -i mysql-apt-config_0.8.10-1_all.deb
 RUN apt-get update
 RUN apt-get -qy install mysql-server
-RUN mysql -e "CREATE USER 'root'@'%'; GRANT ALL ON *.* to 'root'@'%'; FLUSH PRIVILEGES;"
+RUN mysql -e "CREATE USER 'root'@'%'; GRANT ALL ON *.* TO 'root'@'%'; FLUSH PRIVILEGES;"
 
 EXPOSE 8080
 CMD [ "./start_docker.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
 RUN dpkg -i mysql-apt-config_0.8.10-1_all.deb
 RUN apt-get update
 RUN apt-get -qy install mysql-server
+RUN mysql -e "CREATE USER 'root'@'%'; GRANT ALL ON *.* to 'root'@'%'; FLUSH PRIVILEGES;"
 
 EXPOSE 8080
 CMD [ "./start_docker.sh" ]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Before you install WordPress, make sure you have all the required software insta
 *   **Ubuntu Linux:** You'll need the latest version of NodeJS, Yarn and debconf-utils installed first. Follow this [simple guide](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions) to get the latest version of NodeJS installed. Install the rest of the packages using the `apt-get` package manager. _Note: During the WordPress installation, you may be asked to enter the root password at the prompt due to the use of the `sudo` command_
 *   **Docker**: You'll need to install Docker [for your platform](https://www.docker.com/community-edition).
 
-### Install
+### Install locally
 
 The following command will get WordPress running locally on your machine, along with the WordPress plugins you'll need to create and serve custom data via the WP REST API.
 
@@ -39,7 +39,7 @@ The following command will get WordPress running locally on your machine, along 
 > yarn install && yarn start
 ```
 
-#### Install with Docker
+#### OR Install with Docker
 
 ```zsh
 > yarn docker:build && yarn docker:start
@@ -50,6 +50,7 @@ When the installation process completes successfully:
 *   The WordPress REST API is available at [http://localhost:8080](http://localhost:8080)
 *   The WordPress GraphQL API is available at [http://localhost:8080/graphql](http://localhost:8080/graphql)
 *   The WordPress admin is at [http://localhost:8080/wp-admin/](http://localhost:8080/wp-admin/) default login credentials `nedstark` / `winteriscoming`
+*   The MySQL service is available via `mysql -h127.0.0.1 -uroot`
 
 ### Import Data (Optional)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "start": "wp server",
     "lint": "phpcs -v wordpress/wp-content/themes/postlight-headless-wp/. RoboFile.php",
     "docker:build": "docker build . -t wp_headless",
-    "docker:start": "docker run -v $(pwd)/data:/var/lib/mysql -v $(pwd):/usr/src/app -p 8080:8080 -it wp_headless"
+    "docker:start": "docker run -v $(pwd)/data:/var/lib/mysql -v $(pwd):/usr/src/app -p 3306:3306 -p 8080:8080 -it wp_headless"
   }
 }


### PR DESCRIPTION
These changes open up port 3306 on the wp_headless container so MySQL can be accessed by external tools like Sequel Pro.

Note that MySQL should NOT be directly accessible in production!