### PR TITLE
doc: fix deprecated phpcs homebrew package name

### DIFF
--- a/README-linting.md
+++ b/README-linting.md
@@ -12,7 +12,7 @@ To lint your PHP code, you'll need to install PHPCS and the WordPress coding sta
 
 To install the latest stable version of PHPCS with Homebrew on the Mac, run:
 
-`brew install homebrew/php/php-code-sniffer`
+`brew install php-code-sniffer`
 
 ### WordPress Coding Standards
 


### PR DESCRIPTION
The homebrew tap `homebrew/php` has been deprecated as of 31st March 2018: https://github.com/Homebrew/homebrew-php

If you try to install the old package name you get an error:

```
$ brew install homebrew/php/php-code-sniffer    
Error: homebrew/php was deprecated. This tap is now empty as all its formulae were migrated.
```

This PR fixes the homebrew phpcs installation documentation so it uses the new core package name, `php-code-sniffer`.