### PR TITLE
Fix broken apt-get in Dockerfile and update instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get install -yq curl php gnupg wget sudo lsb-release debconf-utils less
+RUN apt-get update && apt-get install -yq curl php gnupg wget sudo lsb-release debconf-utils less
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -14,15 +13,13 @@ COPY docker/install_php_extensions.sh /usr/src/app/install_php_extensions.sh
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update
-RUN apt-get install -yq yarn
+RUN apt-get update && apt-get install -yq yarn
 
 RUN ./install.sh
 RUN ./install_php_extensions.sh
 
 RUN wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
 RUN dpkg -i mysql-apt-config_0.8.10-1_all.deb
-RUN apt-get update
 RUN sudo a2enmod rewrite
 RUN chown -R www-data:www-data /var/www/html/
 
@@ -30,7 +27,5 @@ COPY mysql_config.sh RoboFile.php wp-cli.yml robo.yml /var/www/html/
 COPY docker/000-default.conf /etc/apache2/sites-enabled/
 COPY docker/ports.conf /etc/apache2/
 WORKDIR /var/www/html
-
-RUN apt-get update
 
 CMD apachectl -D FOREGROUND

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ The following commands will get WordPress running on your machine using Docker, 
 ```
 - Setup headless wordpress by running yarn
 ```zsh
-> cd frontend
-> yarn
-> yarn start
+> yarn install
 ```
 When the installation process completes successfully:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The following commands will get WordPress running on your machine using Docker, 
 ```
 - Setup headless wordpress by running yarn
 ```zsh
-> yarn install
+> cd frontend
+> yarn
+> yarn start
 ```
 When the installation process completes successfully:
 


### PR DESCRIPTION
- building the Docker image can fail because apt-get doesn't always persist when it's on its own line in a Dockerfile [1] [2]
```
<snip>
...
Need to get 33.8 MB of archives. After this operation, 156 MB of additional disk space will be used.
Ign:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.0g-2ubuntu4.1
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libssl1.1 amd64 1.1.0g-2ubuntu4.1   404  Not Found [IP: 91.189.88.162 80
Err:2 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libpython3.6-minimal amd64 3.6.6-1~18. 04   404  Not Found [IP: 91.189.88.162 80]
```
- the README instructions for starting the frontend server are slightly wrong

[1] https://stackoverflow.com/a/37727984
[2] https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache