### PR TITLE
fix: draft post/page preview

### DIFF
--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -16,19 +16,35 @@ class Preview extends Component {
 
   componentDidMount() {
     const { url } = this.props;
-    const { id, rev, type, wpnonce } = url.query;
+    const { id, rev, type, status, wpnonce } = url.query;
     // The REST posts controller handles both posts/#/revisions/# and pages/#/revisions/#
     // but the latter isn't documented.
-    fetch(
-      `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`,
-      { credentials: 'include' }, // required for cookie nonce auth
-    )
-      .then(res => res.json())
-      .then(res => {
-        this.setState({
-          post: res,
+
+    // checking if the post/page is a draft or a revision.
+    if( status === 'draft' ) {
+      fetch(
+        `${Config.apiUrl}/wp/v2/${type}s/${rev}?_wpnonce=${wpnonce}`,
+        { credentials: 'include' }, // required for cookie nonce auth
+      )
+        .then(res => res.json())
+        .then(res => {
+          this.setState({
+            post: res,
+          });
         });
-      });
+    }
+    else {
+      fetch(
+        `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`,
+        { credentials: 'include' }, // required for cookie nonce auth
+      )
+        .then(res => res.json())
+        .then(res => {
+          this.setState({
+            post: res,
+          });
+        });
+    }
   }
 
   render() {

--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -21,30 +21,21 @@ class Preview extends Component {
     // but the latter isn't documented.
 
     // checking if the post/page is a draft or a revision.
+    let postUrl = `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`;
     if( status === 'draft' ) {
-      fetch(
-        `${Config.apiUrl}/wp/v2/${type}s/${rev}?_wpnonce=${wpnonce}`,
-        { credentials: 'include' }, // required for cookie nonce auth
-      )
-        .then(res => res.json())
-        .then(res => {
-          this.setState({
-            post: res,
-          });
-        });
+      postUrl = `${Config.apiUrl}/wp/v2/${type}s/${rev}?_wpnonce=${wpnonce}`;
     }
-    else {
-      fetch(
-        `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`,
-        { credentials: 'include' }, // required for cookie nonce auth
-      )
-        .then(res => res.json())
-        .then(res => {
-          this.setState({
-            post: res,
-          });
+
+    fetch(
+      postUrl,
+      { credentials: 'include' }, // required for cookie nonce auth
+    )
+      .then(res => res.json())
+      .then(res => {
+        this.setState({
+          post: res,
         });
-    }
+      });
   }
 
   render() {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -28,10 +28,10 @@ app
       app.render(req, res, actualPage, queryParams);
     });
 
-    server.get('/_preview/:id/:rev/:type/:wpnonce', (req, res) => {
+    server.get('/_preview/:id/:rev/:type/:status/:wpnonce', (req, res) => {
       const actualPage = '/preview';
-      const { id, rev, type, wpnonce } = req.params;
-      const queryParams = { id, rev, type, wpnonce };
+      const { id, rev, type, status, wpnonce } = req.params;
+      const queryParams = { id, rev, type, status, wpnonce };
       app.render(req, res, actualPage, queryParams);
     });
 

--- a/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
+++ b/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
@@ -28,18 +28,38 @@ add_filter( 'wp_terms_checklist_args', 'taxonomy_checklist_checked_ontop_filter'
  * @return str The headless WordPress preview link.
  */
 function set_headless_preview_link( $link ) {
-    $post = get_post( $post );
+    $post = get_post();
     if ( ! $post ) {
         return $link;
     }
- 
+    $status      = 'revision';
     $frontend    = get_frontend_origin();
     $parent_id   = $post->post_parent;
     $revision_id = $post->ID;
     $type        = get_post_type( $parent_id );
     $nonce       = wp_create_nonce( 'wp_rest' );
-
-    return "$frontend/_preview/$parent_id/$revision_id/$type/$nonce";
+    if ( 0 === $parent_id ) {
+        $status = 'draft';
+    }
+    return "$frontend/_preview/$parent_id/$revision_id/$type/$status/$nonce";
 }
 
 add_filter( 'preview_post_link', 'set_headless_preview_link' );
+
+/**
+ * Includes preview link in post data for a response.
+ *
+ * @param \WP_REST_Response $response The response object.
+ * @param \WP_Post          $post     Post object.
+ * @return \WP_REST_Response The response object.
+ */
+function set_preview_link_in_rest_response( $response, $post ) {
+    if ( 'draft' === $post->post_status ) {
+        $response->data['preview_link'] = get_preview_post_link( $post );
+    }
+
+    return $response;
+}
+
+add_filter( 'rest_prepare_post', 'set_preview_link_in_rest_response', 10, 2 );
+add_filter( 'rest_prepare_page', 'set_preview_link_in_rest_response', 10, 2 );


### PR DESCRIPTION
- used the this [comment](https://github.com/postlight/headless-wp-starter/pull/229#issuecomment-535117205) to fix the draft preview issue.
- removed the $post variable in (admin.php) because it was returning an error and being displayed on page load.