### PR TITLE
added a way to run the app instantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ _Optional:_ you can run the frontend locally while WordPress still runs on Docke
 
 Once the containers are running, you can visit the React frontends and backend WordPress admin in your browser.
 
+Run without installation [![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273434815208255488)
+
 ## Frontend
 
 This starter kit provides two frontend containers:


### PR DESCRIPTION
Hello, we are TeamCode. We have created a Tin application for this app, which help users to quickly run and try the app without installing and configuring the environment. Users don't need to pay for this service. Hope it can help you better promote the app. Thx.

[![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=273434815208255488)
Guidance: https://www.teamcode.com/docs/en-US/tin/clone-tin

This is the entire usage process：

Users click the badge Run in Cloud (teamcode demo).
Sign up first if they have not logged in.
After that, they will be directed to the Clone page and start to build & run this app.