### PR TITLE
fix: pass ACFs to graphql

### DIFF
--- a/docker/install_wordpress.sh
+++ b/docker/install_wordpress.sh
@@ -56,6 +56,7 @@ wp plugin install --activate --force \
     jwt-authentication-for-wp-rest-api \
     wp-graphql \
     https://github.com/wp-graphql/wp-graphql-jwt-authentication/archive/refs/tags/v0.4.1.zip \
+    https://github.com/wp-graphql/wp-graphql-acf/archive/master.zip \
     /var/www/plugins/*.zip
 
 wp term update category 1 --name="Sample Category"

--- a/docker/install_wordpress.sh
+++ b/docker/install_wordpress.sh
@@ -44,7 +44,7 @@ wp option update blogdescription "$WORDPRESS_DESCRIPTION"
 wp rewrite structure "$WORDPRESS_PERMALINK_STRUCTURE"
 
 wp theme activate postlight-headless-wp
-wp theme delete twentynineteen twentytwenty twentytwentyone
+wp theme delete twentytwenty twentytwentyone twentytwentytwo
 
 wp plugin delete akismet hello
 wp plugin install --activate --force \

--- a/wordpress/.htaccess
+++ b/wordpress/.htaccess
@@ -1,3 +1,5 @@
+php_value upload_max_filesize 4M
+
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On


### PR DESCRIPTION
## Description
This PR is to allow fields configured in ACF field groups to be passed to graphQL ( they are only being passed to REST ). Refer to [this issue](https://github.com/postlight/headless-wp-starter/issues/201).

* Increased max file size to 4MB ( plugin size ~3.2MB )
* Added `WP graphQL ACF` plugin to Wordpress installation

This adds a new option while creating a new ACF field group

<img width="962" alt="new_acf_option" src="https://user-images.githubusercontent.com/63719442/149474606-da88ddca-2d70-4f48-8213-47efd3acc2af.png">

## Steps
1. Go to [WP admin](http://localhost:8080/wp-admin)
2. Create a new ACF field group including random fields and enable `Show in GraphQL` option
3. Go to [GraphiQL IDE](http://localhost:8080/wp-admin/admin.php?page=graphiql-ide) and now you should be able to query that rule with its corresponding ACF