### PR TITLE
fix: view post/page from WP admin

### DIFF
--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -7,10 +7,8 @@ import Menu from '../components/Menu';
 import Config from '../config';
 
 class Preview extends Component {
-  static async getInitialProps(context) {
-    const { id, rev, type, status, wpnonce } = context.query;
-    const url = { query: { id, rev, type, status, wpnonce } };
-    return { url };
+  static async getInitialProps({ query }) {
+    return { url: { query } };
   }
 
   constructor() {
@@ -28,7 +26,7 @@ class Preview extends Component {
 
     // checking if the post/page is a draft or a revision.
     let postUrl = `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`;
-    if( status === 'draft' ) {
+    if (status === 'draft') {
       postUrl = `${Config.apiUrl}/wp/v2/${type}s/${rev}?_wpnonce=${wpnonce}`;
     }
 
@@ -36,8 +34,8 @@ class Preview extends Component {
       postUrl,
       { credentials: 'include' }, // required for cookie nonce auth
     )
-      .then(res => res.json())
-      .then(res => {
+      .then((res) => res.json())
+      .then((res) => {
         this.setState({
           post: res,
         });

--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -34,8 +34,8 @@ class Preview extends Component {
       postUrl,
       { credentials: 'include' }, // required for cookie nonce auth
     )
-      .then((res) => res.json())
-      .then((res) => {
+      .then(res => res.json())
+      .then(res => {
         this.setState({
           post: res,
         });

--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -7,6 +7,12 @@ import Menu from '../components/Menu';
 import Config from '../config';
 
 class Preview extends Component {
+  static async getInitialProps(context) {
+    const { id, rev, type, status, wpnonce } = context.query;
+    let url = { query: { id, rev, type, status, wpnonce } };
+    return { url };
+  }
+
   constructor() {
     super();
     this.state = {
@@ -22,7 +28,7 @@ class Preview extends Component {
 
     // checking if the post/page is a draft or a revision.
     let postUrl = `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`;
-    if( status === 'draft' ) {
+    if (status === 'draft') {
       postUrl = `${Config.apiUrl}/wp/v2/${type}s/${rev}?_wpnonce=${wpnonce}`;
     }
 
@@ -30,8 +36,8 @@ class Preview extends Component {
       postUrl,
       { credentials: 'include' }, // required for cookie nonce auth
     )
-      .then(res => res.json())
-      .then(res => {
+      .then((res) => res.json())
+      .then((res) => {
         this.setState({
           post: res,
         });

--- a/frontend/pages/preview.js
+++ b/frontend/pages/preview.js
@@ -9,7 +9,7 @@ import Config from '../config';
 class Preview extends Component {
   static async getInitialProps(context) {
     const { id, rev, type, status, wpnonce } = context.query;
-    let url = { query: { id, rev, type, status, wpnonce } };
+    const url = { query: { id, rev, type, status, wpnonce } };
     return { url };
   }
 
@@ -28,7 +28,7 @@ class Preview extends Component {
 
     // checking if the post/page is a draft or a revision.
     let postUrl = `${Config.apiUrl}/wp/v2/${type}s/${id}/revisions/${rev}?_wpnonce=${wpnonce}`;
-    if (status === 'draft') {
+    if( status === 'draft' ) {
       postUrl = `${Config.apiUrl}/wp/v2/${type}s/${rev}?_wpnonce=${wpnonce}`;
     }
 
@@ -36,8 +36,8 @@ class Preview extends Component {
       postUrl,
       { credentials: 'include' }, // required for cookie nonce auth
     )
-      .then((res) => res.json())
-      .then((res) => {
+      .then(res => res.json())
+      .then(res => {
         this.setState({
           post: res,
         });

--- a/wordpress/.gitignore
+++ b/wordpress/.gitignore
@@ -15,3 +15,4 @@
 /wp-content/debug.log
 /wp-content/uploads/**
 twentytwentyone/
+twentytwentytwo/

--- a/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
+++ b/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
@@ -29,7 +29,7 @@ add_filter( 'wp_terms_checklist_args', 'taxonomy_checklist_checked_ontop_filter'
  */
 function set_headless_preview_link( $link ) {
     $post = get_post();
-    $post_status = get_post_status($post);
+    $post_status = get_post_status( $post );
 
     if ( ! $post ) {
         return $link;
@@ -44,7 +44,7 @@ function set_headless_preview_link( $link ) {
         $status = 'draft';
     }
 
-    if('publish' === $post_status){
+    if ( 'publish' === $post_status ) {
         $post_slug = $post->post_name;
         return "$frontend/$type/$post_slug";
     }

--- a/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
+++ b/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
@@ -29,6 +29,8 @@ add_filter( 'wp_terms_checklist_args', 'taxonomy_checklist_checked_ontop_filter'
  */
 function set_headless_preview_link( $link ) {
     $post = get_post();
+    $post_status = get_post_status($post);
+
     if ( ! $post ) {
         return $link;
     }
@@ -41,6 +43,12 @@ function set_headless_preview_link( $link ) {
     if ( 0 === $parent_id ) {
         $status = 'draft';
     }
+
+    if('publish' === $post_status){
+        $post_slug = $post->post_name;
+        return "$frontend/$type/$post_slug";
+    }
+
     return "$frontend/_preview/$parent_id/$revision_id/$type/$status/$nonce";
 }
 

--- a/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
+++ b/wordpress/wp-content/themes/postlight-headless-wp/inc/admin.php
@@ -46,6 +46,9 @@ function set_headless_preview_link( $link ) {
 
 add_filter( 'preview_post_link', 'set_headless_preview_link' );
 
+add_filter( 'post_link', 'set_headless_preview_link' );
+add_filter( 'page_link', 'set_headless_preview_link' );
+
 /**
  * Includes preview link in post data for a response.
  *


### PR DESCRIPTION
## Description:
The purpose of this PR is to enable view posts and pages from WP admin post/page list.
Refer to [this issue](https://github.com/postlight/headless-wp-starter/issues/186)

## GIFs
#### Before
![Screen Recording 2022-02-07 at 4 41 10 PM](https://user-images.githubusercontent.com/64750380/152843502-291f6489-329d-483a-bef2-496f55c95f6b.gif)

#### After
![Screen Recording 2022-02-07 at 4 39 30 PM](https://user-images.githubusercontent.com/64750380/152843526-5e7be36e-d9c1-459d-a72d-238f016bf627.gif)