### PR TITLE
a Composer plugin which is blocked by your allow-plugins config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN curl -sL https://raw.githubusercontent.com/composer/getcomposer.org/master/w
 	mkdir /var/www/.composer; \
 	chown www-data:www-data /var/www/.composer
 
+RUN sudo -u www-data composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true
+
 # phpunit, phpcs, wpcs
 RUN sudo -u www-data composer global require \
 	phpunit/phpunit \


### PR DESCRIPTION
`docker compose up -d`

#0 6.143 In PluginManager.php line 738:
#0 6.143                                                                                
#0 6.143   dealerdirect/phpcodesniffer-composer-installer (installed globally) contain  
#0 6.143   s a Composer plugin which is blocked by your allow-plugins config. You may   
#0 6.143   add it to the list if you consider it safe.                                  
#0 6.143   You can run "composer global config --no-plugins allow-plugins.dealerdirect  
#0 6.143   /phpcodesniffer-composer-installer [true|false]" to enable it (true) or dis  
#0 6.143   able it explicitly and suppress this exception (false)                       
#0 6.143   See https://getcomposer.org/allow-plugins  