### PR TITLE
fix: add parenthesis to nested ternary operator

### DIFF
--- a/wordpress/wp-content/themes/postlight-headless-wp/inc/log.php
+++ b/wordpress/wp-content/themes/postlight-headless-wp/inc/log.php
@@ -40,7 +40,7 @@ function log_console( $name, $data = null, $js_eval = false ) {
     $replace_array = array( '"', '', '', '\\n', '\\n' );
     $data          = preg_replace( $search_array, $replace_array, $data );
     $data          = ltrim( rtrim( $data, '"' ), '"' );
-    $data          = $is_evaled ? $data : ( "'" === $data[0] ) ? $data : "'" . $data . "'";
+    $data          = $is_evaled ? $data : (( "'" === $data[0] ) ? $data : "'" . $data . "'");
 
     $js = <<<JSCODE
 \n<script>


### PR DESCRIPTION
Fixes PHP code format error that caused admin site to not load - adds missing parenthesis to nested ternary operator.

```
PHP Fatal error:  Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in /var/www/html/wp-content/themes/postlight-headless-wp/inc/log.php on line 44
```